### PR TITLE
Reorganize embedding backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,18 +40,21 @@ openground is an on-device RAG system that extracts documentation from git repos
 
 ### Installation
 
-Recommended to install with [uv](https://docs.astral.sh/uv/):
+Recommended to install with [uv](https://docs.astral.sh/uv/).
+You must choose one of the backends, as shown here:
 
 ```bash
-uv tool install openground # Larger package size, automatic GPU/MPS/CPU support
-uv tool install 'openground[fastembed]' # Lightweight CPU support
-uv tool install 'openground[fastembed-gpu]' # Experimental CUDA/GPU support through fastembed
+uv tool install 'openground[fastembed-cpu]'        # CPU
+uv tool install 'openground[fastembed-gpu]'        # CUDA GPU (Linux/Windows)
+uv tool install 'openground[sentence-transformers]' # auto GPU/MPS/CPU
 ```
 
 or
 
 ```bash
-pip install openground
+pip install 'openground[fastembed-cpu]'
+pip install 'openground[fastembed-gpu]'
+pip install 'openground[sentence-transformers]'
 ```
 
 ### Add Documentation
@@ -192,8 +195,8 @@ Now your AI assistant can search your stored documentation automatically!
 Here's how to add the fastembed documentation and make it available to Claude Code:
 
 ```bash
-# 1. Install openground
-uv tool install openground
+# 1. Install openground with a backend
+uv tool install 'openground[fastembed-cpu]'
 
 # 2. Add fastembed to openground
 openground add fastembed --source https://github.com/qdrant/fastembed.git --docs-path docs/ --version v0.7.4 -y

--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ pip install 'openground[fastembed-gpu]'
 pip install 'openground[sentence-transformers]'
 ```
 
+If you install openground without a backend, the CLI will start but it will
+warn immediately that no embedding backend is installed. Commands that need
+embeddings, including `add`, `embed`, `query`, and the MCP server, will stop
+with a clear message until you install one of the backends above.
+
 ### Add Documentation
 
 Openground can source documentation from git repos, sitemaps, or local directories.

--- a/openground/cli.py
+++ b/openground/cli.py
@@ -23,6 +23,11 @@ from openground.config import (
     DEFAULT_LIBRARY_VERSION,
 )
 from openground.console import success, error, hint, warning
+from openground.embeddings import (
+    has_any_embedding_backend,
+    require_any_embedding_backend,
+    warn_if_no_embedding_backend,
+)
 from openground.extract.source import get_library_config, load_source_file
 from openground.query import library_version_exists, list_libraries_with_versions
 
@@ -124,6 +129,10 @@ def ensure_config_exists(ctx: typer.Context):
     # Load the effective config (now that we know it exists)
     get_effective_config()
 
+    command = ctx.invoked_subcommand
+    if command not in {"add", "embed", "query"}:
+        warn_if_no_embedding_backend()
+
     # Notify user if we just created it
     if not file_existed and config_path.exists():
         success(f"Config file created at {config_path}\n")
@@ -197,6 +206,8 @@ def add(
     For git and local path sources, the following file extensions are parsed: .md, .rst, .txt, .mdx, .ipynb, .html, .htm
     """
     from rich.console import Console
+
+    require_any_embedding_backend()
 
     console = Console()
     config = get_effective_config()
@@ -706,6 +717,8 @@ def embed(
     """Chunk documents, generate embeddings, and embed into the local db."""
     from rich.console import Console
 
+    require_any_embedding_backend()
+
     console = Console()
     with console.status("[bold green]"):
         from openground.ingest import ingest_to_lancedb, load_parsed_pages
@@ -742,6 +755,8 @@ def query_cmd(
 ):
     """Run a hybrid search (semantic + BM25) against the local db."""
     from openground.query import search
+
+    require_any_embedding_backend()
 
     # Get config
     config = get_effective_config()

--- a/openground/embeddings.py
+++ b/openground/embeddings.py
@@ -11,6 +11,50 @@ from openground.config import get_effective_config
 from openground.console import error, hint, warning
 
 
+def has_any_embedding_backend() -> bool:
+    """Return True if at least one embedding backend is installed."""
+    try:
+        import fastembed  # noqa: F401
+
+        return True
+    except ImportError:
+        pass
+
+    try:
+        import sentence_transformers  # noqa: F401
+        import torch  # noqa: F401
+
+        return True
+    except ImportError:
+        pass
+
+    return False
+
+
+def warn_if_no_embedding_backend() -> None:
+    """Warn, but do not fail, if no embedding backend is installed."""
+    if has_any_embedding_backend():
+        return
+
+    warning("Warning: openground installed without embeddings.\n")
+
+
+def require_any_embedding_backend() -> None:
+    """Exit with a clear error if no embedding backend is installed."""
+    if has_any_embedding_backend():
+        return
+
+    error(
+        "Error: openground installed without embeddings.\n\n"
+        "To perform this command, install one of:\n\n"
+        "  uv tool install openground[fastembed-cpu]\n"
+        "  uv tool install openground[fastembed-gpu]\n"
+        "  uv tool install openground[sentence-transformers]\n"
+
+    )
+    raise SystemExit(1)
+
+
 @lru_cache(maxsize=1)
 def get_st_model(model_name: str):
     """Get a cached instance of SentenceTransformer."""

--- a/openground/embeddings.py
+++ b/openground/embeddings.py
@@ -71,7 +71,7 @@ def check_gpu_compatibility() -> None:
             "\nWarning: openground[fastembed-gpu] is installed but no NVIDIA GPU was detected."
         )
         warning("   You may want to switch to the CPU version:")
-        warning("   uv tool install 'openground[fastembed]'\n")
+        warning("   uv tool install 'openground[fastembed-cpu]'\n")
 
     elif gpu_hardware and has_gpu_pkg and not functional_gpu:
         error(
@@ -83,7 +83,7 @@ def check_gpu_compatibility() -> None:
         error(
             "   See: https://oliviajain.github.io/onnxruntime/docs/execution-providers/CUDA-ExecutionProvider.html\n"
         )
-        error("  2. Install the CPU version: uv tool install 'openground[fastembed]'")
+        error("  2. Install the CPU version: uv tool install 'openground[fastembed-cpu]'")
         error(
             "  3. If you still want gpu performance, you can install the more bulky"
             "sentence-transformers backend: uv tool install 'openground[sentence-transformers]'"

--- a/openground/server.py
+++ b/openground/server.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from fastmcp import FastMCP
 
 from openground.config import get_effective_config
+from openground.embeddings import require_any_embedding_backend, warn_if_no_embedding_backend
 from openground.query import (
     get_full_content,
     list_libraries_with_versions,
@@ -162,6 +163,7 @@ def get_full_content_tool(url: str, version: str) -> str:
 
 def run_server():
     """Entry point for the MCP server."""
+    require_any_embedding_backend()
     threading.Thread(target=_pre_load_resources, daemon=True).start()
 
     mcp.run(transport="stdio")

--- a/openground/tests/test_cli.py
+++ b/openground/tests/test_cli.py
@@ -77,6 +77,7 @@ def test_add_git_source_creates_raw_data(temp_config_dir, mock_config):
 
     # Mock the extraction and ingestion pipeline to avoid network calls
     with (
+        patch("openground.cli.require_any_embedding_backend"),
         patch("openground.extract.git.extract_repo", side_effect=mock_extract_repo),
         patch("openground.ingest.ingest_to_lancedb"),
         patch("openground.ingest.load_parsed_pages", return_value=[]),
@@ -108,6 +109,7 @@ def test_add_sitemap_source_creates_raw_data(temp_config_dir, mock_config):
 
     # Mock the extraction and ingestion pipeline to avoid network calls
     with (
+        patch("openground.cli.require_any_embedding_backend"),
         patch(
             "openground.extract.sitemap.extract_pages", side_effect=mock_extract_pages
         ),
@@ -524,6 +526,7 @@ class TestAddUpdateDetection:
             (output_dir / "test.json").write_text('{"url": "https://example.com"}')
 
         with (
+            patch("openground.cli.require_any_embedding_backend"),
             patch(
                 "openground.extract.sitemap.extract_pages",
                 side_effect=mock_extract_pages,
@@ -585,6 +588,7 @@ class TestAddUpdateDetection:
             (output_dir / "test.json").write_text('{"url": "https://example.com"}')
 
         with (
+            patch("openground.cli.require_any_embedding_backend"),
             patch(
                 "openground.extract.sitemap.extract_pages",
                 side_effect=mock_extract_pages,
@@ -683,6 +687,7 @@ class TestAddUpdateDetection:
         # Note: We can't test the full update flow due to fastembed import issues
         # But we can verify the detection logic works correctly
         with (
+            patch("openground.cli.require_any_embedding_backend"),
             patch(
                 "openground.extract.sitemap.extract_pages",
                 side_effect=mock_extract_pages,
@@ -898,6 +903,7 @@ class TestLocalPathExtraction:
 
         # Mock the ingestion to avoid embedding overhead
         with (
+            patch("openground.cli.require_any_embedding_backend"),
             patch("openground.ingest.ingest_to_lancedb"),
             patch("openground.ingest.load_parsed_pages", return_value=[]),
         ):
@@ -949,6 +955,7 @@ class TestLocalPathExtraction:
 
         # Mock the ingestion
         with (
+            patch("openground.cli.require_any_embedding_backend"),
             patch("openground.ingest.ingest_to_lancedb"),
             patch("openground.ingest.load_parsed_pages", return_value=[]),
         ):
@@ -1038,6 +1045,7 @@ class TestLocalPathExtraction:
 
         # Mock the ingestion to avoid embedding overhead
         with (
+            patch("openground.cli.require_any_embedding_backend"),
             patch("openground.ingest.ingest_to_lancedb"),
             patch("openground.ingest.load_parsed_pages", return_value=[]),
         ):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,13 +39,12 @@ dependencies = [
     "pandas>=2.3.3,<3.0.0",
     "rich>=14.0.0,<15.0.0",
     "nbformat>=5.0.0,<6.0.0",
-    "sentence-transformers>=5.0.0,<6.0.0",
-    "torch>=2.0.0,<3.0.0",
 ]
 
 [project.optional-dependencies]
 fastembed-cpu = ["fastembed>=0.2.0,<1.0.0"]
 fastembed-gpu = ["fastembed-gpu>=0.2.0,<1.0.0"]
+sentence-transformers = ["sentence-transformers>=5.0.0,<6.0.0", "torch>=2.0.0,<3.0.0"]
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -1998,7 +1998,7 @@ wheels = [
 
 [[package]]
 name = "openground"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -2009,8 +2009,6 @@ dependencies = [
     { name = "pandas" },
     { name = "pydantic" },
     { name = "rich" },
-    { name = "sentence-transformers" },
-    { name = "torch" },
     { name = "tqdm" },
     { name = "trafilatura" },
     { name = "typer" },
@@ -2022,6 +2020,10 @@ fastembed-cpu = [
 ]
 fastembed-gpu = [
     { name = "fastembed-gpu" },
+]
+sentence-transformers = [
+    { name = "sentence-transformers" },
+    { name = "torch" },
 ]
 
 [package.dev-dependencies]
@@ -2051,13 +2053,13 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.3,<3.0.0" },
     { name = "pydantic", specifier = ">=2.0.0,<3.0.0" },
     { name = "rich", specifier = ">=14.0.0,<15.0.0" },
-    { name = "sentence-transformers", specifier = ">=5.0.0,<6.0.0" },
-    { name = "torch", specifier = ">=2.0.0,<3.0.0" },
+    { name = "sentence-transformers", marker = "extra == 'sentence-transformers'", specifier = ">=5.0.0,<6.0.0" },
+    { name = "torch", marker = "extra == 'sentence-transformers'", specifier = ">=2.0.0,<3.0.0" },
     { name = "tqdm", specifier = ">=4.60.0" },
     { name = "trafilatura", specifier = ">=2.0.0,<3.0.0" },
     { name = "typer", specifier = ">=0.9.0,<1.0.0" },
 ]
-provides-extras = ["fastembed-cpu", "fastembed-gpu"]
+provides-extras = ["fastembed-cpu", "fastembed-gpu", "sentence-transformers"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
# Description

This PR reorganizes packaging so embedding backends are optional extras and the CLI gives clear guidance when none are installed.

# Why?

I work on an Intel-based Macintosh for some legacy projects, and quickly found that the CPU-only `fastembed` backend  still installs `torch` and `sentence-transformers` because those two packages are listed as core dependencies.  However, torch doesn't ship wheels for Intel Macs any longer.

By moving all the backends out of the core, we can still get to all the backend configurations that exist today but the cpu-only option doesn't try to pull in torch any more. 

# What changed
- Made the core install backend-free
- Now `fastembed-cpu`,`fastembed-gpu`, and `sentence-transformers` are optional extras
- Added launch-time notification if backends are missing:
  - warning for commands that don't use embeddings (list, nuke, etc)
  - hard error for commands that require embeddings (query, add, mcp)
- Updated tests to mock this backend check (as the test cases don't call the backend)

# Example

```
$ uv tool install openground --python 3.11
$ openground add usd-core-spec --source https://github.com/aousd/specifications-public.git --docs-path core/1.0.1/
Error: openground installed without embeddings.

To perform this command, install one of:

  uv tool install openground[fastembed-cpu]
  uv tool install openground[fastembed-gpu]
  uv tool install openground[sentence-transformers]

```

# Testing
- uv run pytest -q
- Result: 59 passed, 1 skipped
